### PR TITLE
Provider Not Found Fix

### DIFF
--- a/src/Provider/StatesServiceProvider.php
+++ b/src/Provider/StatesServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mercyware\States\Providers;
+namespace Mercyware\States\Provider;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/Providers/StatesServiceProvider.php
+++ b/src/Providers/StatesServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mercyware\States\Provider;
+namespace Mercyware\States\Providers;
 
 use Illuminate\Support\ServiceProvider;
 


### PR DESCRIPTION
When running php artisan commands, the error "Class Mercyware\States\Provider\StatesServiceProvider" not found gets thrown.

Checking through, the namespace is wrongly typed Mercyware\States\Provider instead of Mercyware\States\Providers.